### PR TITLE
Add import trial app to VS Code link

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -19,6 +19,19 @@ function getTASData() {
     'href',
     'vscode://vscode.git/clone?url=' + encodeURIComponent(data.gitUrl)
   );
+
+  const importVSCode = document.getElementById('import');
+  importVSCode.setAttribute(
+    'href',
+    `vscode://ms-azuretools.vscode-azureappservice/ImportTrialApp?loginSession=${data.loginSession}`
+  );
+
+  const importInsiders = document.getElementById('import');
+  importInsiders.setAttribute(
+    'href',
+    `vscode-insiders://ms-azuretools.vscode-azureappservice/ImportTrialApp?loginSession=${data.loginSession}`
+  );
+
   const creds = document.getElementById('creds');
   if (navigator.platform === 'Win32') {
     creds.textContent = data.gitUrl;

--- a/public/script.js
+++ b/public/script.js
@@ -26,7 +26,7 @@ function getTASData() {
     `vscode://ms-azuretools.vscode-azureappservice/ImportTrialApp?loginSession=${data.loginSession}`
   );
 
-  const importInsiders = document.getElementById('import');
+  const importInsiders = document.getElementById('insiders');
   importInsiders.setAttribute(
     'href',
     `vscode-insiders://ms-azuretools.vscode-azureappservice/ImportTrialApp?loginSession=${data.loginSession}`

--- a/public/script.js
+++ b/public/script.js
@@ -54,6 +54,7 @@ setInterval(() => {
   if (!isNaN(env.timeLeft) && env.timeLeft > 0)
   {
     env.timeLeft -=3;
+    env.timeLeft = (env.timeLeft < 0) ? 0 : env.timeLeft;
     el.textContent = timeToString(env.timeLeft);
   }
 }, 3000);

--- a/public/style.css
+++ b/public/style.css
@@ -148,6 +148,10 @@ a {
   margin-top:10px;
 }
 
+.link {
+  list-style-type: none;
+}
+
 .column .description {
   margin: 2px 0 8px;
   color: #666;

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@
 var util = require('./util');
 const express = require('express');
 const http = require('http');
-const url = require('url'); 
+const url = require('url');
 var cookieParser = require('cookie-parser');
 const request = require('request');
 
@@ -15,37 +15,46 @@ async function main() {
   app.use(cookieParser());
 
   app.get('/', async (req, res) => {
-    if(req.query && req.query.loginsession)
-    {
-    res.cookie('loginsession',req.query.loginsession, { maxAge: 3600000, httpOnly: true, })
-    res.redirect(url.parse(req.url).pathname);
+    if (req.query && req.query.loginsession) {
+      res.cookie('loginsession', req.query.loginsession, { maxAge: 3600000, httpOnly: true, })
+      res.redirect(url.parse(req.url).pathname);
     }
-    else
-    {
-    let indexContent = await util.loadEnvironmentVariables({host: process.env['HTTP_HOST']});
-    res.end(indexContent);
+    else {
+      let indexContent = await util.loadEnvironmentVariables({ host: process.env['HTTP_HOST'] });
+      res.end(indexContent);
+    }
+  });
+
+  app.get('/trial', async (req, res) => {
+    if (req.query && req.query.loginsession) {
+      res.cookie('loginsession', req.query.loginsession, { maxAge: 3600000, httpOnly: true, })
+      res.redirect(url.parse(req.url).pathname);
+    }
+    else {
+      let indexContent = await util.loadEnvironmentVariablesTrial({ host: process.env['HTTP_HOST'] });
+      res.end(indexContent);
     }
   });
 
   app.get('/api/metadata', async (req, res) => {
     if (req.cookies.loginsession) {
-      let tryappserviceendpoint= (process.env['APPSETTING_TRYAPPSERVICE_URL'] || 'https://tryappservice.azure.com') + '/api/vscoderesource';
+      let tryappserviceendpoint = (process.env['APPSETTING_TRYAPPSERVICE_URL'] || 'https://tryappservice.azure.com') + '/api/vscoderesource';
       const options = {
         url: tryappserviceendpoint,
-        headers:{
-            cookie: 'loginsession='+req.cookies.loginsession
+        headers: {
+          cookie: 'loginsession=' + req.cookies.loginsession
         }
       };
-      
-  const x =request(options);
-  x.pipe(res);
-}
-else{
-  res.end(404);
-}
-});
 
-// Create the HTTP server.
+      const x = request(options);
+      x.pipe(res);
+    }
+    else {
+      res.end(404);
+    }
+  });
+
+  // Create the HTTP server.
   let server = http.createServer(app);
   server.listen(PORT, function () {
     console.log(`Listening on port ${PORT}`);

--- a/template.html
+++ b/template.html
@@ -41,13 +41,13 @@
 
           <div>
             <p class="title">Get the code</p>
-            <p> Import the app into VS Code using the Azure App Service extension, clone the source using Visual Studio
+            <p> Import app into VS Code using the Azure App Service extension, clone the source using Visual Studio
               Code, or use git from the command line.</p>
 
             <div>
               <p class="link">
               <ul class="link">
-                <li><a href="#" id="import">Import app into VS Code</a><a style="margin-left: 10px" href="#" id="import">Import app into VS Code Insiders</a></li>
+                <li><a href="#" id="import">Import app into VS Code</a><a style="margin-left: 10px" href="#" id="insiders">Import app into VS Code Insiders</a></li>
                 <li><a href="#" id="clone">Clone with VS Code</a> <a style="margin-left: 10px" href="#" id="show-creds">Clone with HTTPS</a></li>
               </ul>
               </p>
@@ -93,12 +93,10 @@
               onclick="window.open('https://azure.microsoft.com/en-us/free/?utm_source=campaign&utm_campaign=vscode-tryappservice&mktingSource=vscode-tryappservice', '_blank')">
               GET A FREE SUBSCRIPTION
             </button>
-            <button class="feedback-btn" type="button"
-              onclick="window.open('https://aka.ms/tas-node-walkthrough','_blank')">
+            <button class="feedback-btn" type="button" onclick="window.open('https://aka.ms/tas-node-walkthrough','_blank')">
               READ THE DOCS
             </button>
-            <button class="feedback-btn" type="button"
-              onclick="window.open('https://www.surveymonkey.com/r/56RHP72','_blank')">
+            <button class="feedback-btn" type="button" onclick="window.open('https://www.surveymonkey.com/r/56RHP72','_blank')">
               I RAN INTO AN ISSUE
             </button>
           </div>

--- a/template.html
+++ b/template.html
@@ -41,12 +41,15 @@
 
           <div>
             <p class="title">Get the code</p>
-            <p> Clone the source using Visual Studio Code or use git from the command line.</p>
+            <p> Import the app into VS Code using the Azure App Service extension, clone the source using Visual Studio
+              Code, or use git from the command line.</p>
 
             <div>
               <p class="link">
-                <a href="#" id="clone">Clone with VS Code</a>
-                <a style="margin-left: 10px" href="#" id="show-creds">Clone with HTTPS</a>
+              <ul class="link">
+                <li><a href="#" id="import">Import app into VS Code</a><a style="margin-left: 10px" href="#" id="import">Import app into VS Code Insiders</a></li>
+                <li><a href="#" id="clone">Clone with VS Code</a> <a style="margin-left: 10px" href="#" id="show-creds">Clone with HTTPS</a></li>
+              </ul>
               </p>
             </div>
 
@@ -86,13 +89,16 @@
       <div class="content2">
         <div class="centered">
           <div>
-            <button class="continue-btn" type="button" onclick="window.open('https://azure.microsoft.com/en-us/free/?utm_source=campaign&utm_campaign=vscode-tryappservice&mktingSource=vscode-tryappservice', '_blank')">
+            <button class="continue-btn" type="button"
+              onclick="window.open('https://azure.microsoft.com/en-us/free/?utm_source=campaign&utm_campaign=vscode-tryappservice&mktingSource=vscode-tryappservice', '_blank')">
               GET A FREE SUBSCRIPTION
             </button>
-            <button class="feedback-btn" type="button" onclick="window.open('https://aka.ms/tas-node-walkthrough','_blank')">
+            <button class="feedback-btn" type="button"
+              onclick="window.open('https://aka.ms/tas-node-walkthrough','_blank')">
               READ THE DOCS
             </button>
-            <button class="feedback-btn" type="button" onclick="window.open('https://www.surveymonkey.com/r/56RHP72','_blank')">
+            <button class="feedback-btn" type="button"
+              onclick="window.open('https://www.surveymonkey.com/r/56RHP72','_blank')">
               I RAN INTO AN ISSUE
             </button>
           </div>

--- a/template.html
+++ b/template.html
@@ -41,15 +41,12 @@
 
           <div>
             <p class="title">Get the code</p>
-            <p> Import app into VS Code using the Azure App Service extension, clone the source using Visual Studio
-              Code, or use git from the command line.</p>
+            <p> Clone the source using Visual Studio Code or use git from the command line.</p>
 
             <div>
               <p class="link">
-              <ul class="link">
-                <li><a href="#" id="import">Import app into VS Code</a><a style="margin-left: 10px" href="#" id="insiders">Import app into VS Code Insiders</a></li>
-                <li><a href="#" id="clone">Clone with VS Code</a> <a style="margin-left: 10px" href="#" id="show-creds">Clone with HTTPS</a></li>
-              </ul>
+                <a href="#" id="clone">Clone with VS Code</a>
+                <a style="margin-left: 10px" href="#" id="show-creds">Clone with HTTPS</a>
               </p>
             </div>
 
@@ -93,10 +90,12 @@
               onclick="window.open('https://azure.microsoft.com/en-us/free/?utm_source=campaign&utm_campaign=vscode-tryappservice&mktingSource=vscode-tryappservice', '_blank')">
               GET A FREE SUBSCRIPTION
             </button>
-            <button class="feedback-btn" type="button" onclick="window.open('https://aka.ms/tas-node-walkthrough','_blank')">
+            <button class="feedback-btn" type="button"
+              onclick="window.open('https://aka.ms/tas-node-walkthrough','_blank')">
               READ THE DOCS
             </button>
-            <button class="feedback-btn" type="button" onclick="window.open('https://www.surveymonkey.com/r/56RHP72','_blank')">
+            <button class="feedback-btn" type="button"
+              onclick="window.open('https://www.surveymonkey.com/r/56RHP72','_blank')">
               I RAN INTO AN ISSUE
             </button>
           </div>

--- a/templateTRIAL.html
+++ b/templateTRIAL.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="shortcut icon" href="./images/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="./images/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="style.css">
+    <script src="./script.js"></script>
+    <script>{ envVars }</script>
+    <title>Express App</title>
+</head>
+
+<body onload="getTASData()">
+
+    <!-- Hero -->
+    <div id="hero">
+        <p id="countdown">This <strong>free</strong> web application will expire in
+            <strong id="timeLeft">...</strong>
+            minutes...
+        </p>
+        <img src="./images/node-logo.svg" alt="Azure App Service">
+
+        <!-- Make some edits!! -->
+        <h1> Welcome to Azure! </h1>
+
+        <p>This is a simple Node application hosted on Azure App Service at <a href="/" id='host'></a></p>
+
+    </div>
+
+
+    <!-- Content -->
+    <div>
+        <div class="content-wrapper">
+            <div class="content">
+                <div class="column">
+                    <div class="numberCircle">
+                        1
+                    </div>
+
+                    <div>
+                        <p class="title">Get the code</p>
+                        <p> Import app into VS Code using the Azure App Service extension, clone the source using Visual
+                            Studio
+                            Code, or use git from the command line.</p>
+
+                        <div>
+                            <p class="link">
+                            <ul class="link">
+                                <li><a href="#" id="import">Import app into VS Code</a><a style="margin-left: 10px"
+                                        href="#" id="insiders">Import app into VS Code Insiders</a></li>
+                                <li><a href="#" id="clone">Clone with VS Code</a> <a style="margin-left: 10px" href="#"
+                                        id="show-creds">Clone with HTTPS</a></li>
+                            </ul>
+                            </p>
+                        </div>
+
+                        <div>
+                            <p class="link">
+                            </p>
+                            <p id="creds" style="display: none"></p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="column">
+                    <div class="numberCircle">
+                        2
+                    </div>
+                    <div>
+                        <p class="title">Make some changes</p>
+                        <p> Edit <span class="code">template.html</span> and run <span class="code">npm start</span> (or
+                            press F5
+                            in VS Code!) to run the application locally.</p>
+                    </div>
+                </div>
+
+                <div class="column">
+                    <div class="numberCircle">
+                        3
+                    </div>
+                    <div>
+                        <p class="title">Deploy your changes</p>
+                        <p> Commit your changes, <span class="code">git push</span> to redeploy, then refresh this page.
+                        </p>
+
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div>
+            <div class="content2">
+                <div class="centered">
+                    <div>
+                        <button class="continue-btn" type="button"
+                            onclick="window.open('https://azure.microsoft.com/en-us/free/?utm_source=campaign&utm_campaign=vscode-tryappservice&mktingSource=vscode-tryappservice', '_blank')">
+                            GET A FREE SUBSCRIPTION
+                        </button>
+                        <button class="feedback-btn" type="button"
+                            onclick="window.open('https://aka.ms/tas-node-walkthrough','_blank')">
+                            READ THE DOCS
+                        </button>
+                        <button class="feedback-btn" type="button"
+                            onclick="window.open('https://www.surveymonkey.com/r/56RHP72','_blank')">
+                            I RAN INTO AN ISSUE
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+</body>
+
+</html>

--- a/util.js
+++ b/util.js
@@ -1,7 +1,16 @@
 //@ts-check
 const fs = require('fs');
-module.exports.loadEnvironmentVariables = async function(updateObject) {    
+module.exports.loadEnvironmentVariables = async function (updateObject) {
     return await fs.readFileSync(`${__dirname}/template.html`, 'utf8')
+        .replace(
+            '{ envVars }',
+            `let env = ` +
+            JSON.stringify(updateObject)
+        );
+}
+
+module.exports.loadEnvironmentVariablesTrial = async function (updateObject) {
+    return await fs.readFileSync(`${__dirname}/templateTRIAL.html`, 'utf8')
         .replace(
             '{ envVars }',
             `let env = ` +


### PR DESCRIPTION
Hi, I am working on the [vscode-azureappservice](https://github.com/microsoft/vscode-azureappservice) extension. We are adding a new feature that enables users to import trial apps created by the TryAppService API through a Uri.

I have added these links to the template so that users can import their trial web app into VS Code right from the browser.

I have also fixed a bug where the time left of your trial app becomes -1.

I have hidden these changes in the /trial endpoint. So that this feature isn't exposed to users.

