### PR TITLE
Add .deployment file with scmDoBuild=true

### DIFF
--- a/.deployment
+++ b/.deployment
@@ -1,0 +1,2 @@
+[config]
+SCM_DO_BUILD_DURING_DEPLOYMENT=true


### PR DESCRIPTION
This is to make transferring (deploying) the trial template to an app service app can be done without additional code within the Azure App Service extension for VS Code.